### PR TITLE
WeakEnemyの左右に曲がる方向をcsvで指定できるようにした。

### DIFF
--- a/DirectXGame/3D/ParticleManager.cpp
+++ b/DirectXGame/3D/ParticleManager.cpp
@@ -303,14 +303,15 @@ void ParticleManager::Fire(Particle* particle, int life, const XMFLOAT3& pos_, f
 {
 	for (int i = 0; i < setNum; i++)
 	{
-		//X,Y,Z全て{-20.0f,20.0f}でランダムに分布
-		const float md_pos_x = setpos_x;
-		const float md_pos_y = setpos_y;
-		const float md_pos_z = setpos_z;
+		//乱数生成装置
+		std::random_device seed_gen;
+		std::mt19937_64 engine(seed_gen());
+		std::uniform_real_distribution<float>dist(-4.5f, 4.5f);
+
 		XMFLOAT3 pos = pos_;
-		pos.x = (float)rand() / RAND_MAX * setpos_x - setpos_x1 / 2.0f;
-		pos.y = (float)rand() / RAND_MAX * setpos_y - setpos_y1 / 2.0f;
-		pos.z = (float)rand() / RAND_MAX * setpos_z - setpos_z1 / 2.0f;
+		pos.x += dist(engine);
+		pos.y += dist(engine);
+		pos.z += dist(engine);
 		//X,Y,Z全て{0.1f,0.1f}でランダムに分布
 		const float md_vel_x = setvel_x;
 		const float md_vel_y = setvel_y;

--- a/DirectXGame/GameObject/Enemy.h
+++ b/DirectXGame/GameObject/Enemy.h
@@ -34,8 +34,12 @@ public:
 	//“–‚½‚è”»’èXV
 	void ColliderUpdate();
 
-	//gameScene‚Ìsetter
+	//setter
+	//gameScene
 	void SetGameScene(GamePlayScene* gameScene) { gameScene_ = gameScene; }
+
+	//phase
+	void SetPhase(Phase phase) { phase_ = phase; }
 
 	bool GetIsDead() const { return isDead_; }
 

--- a/DirectXGame/GameObject/EnemyBullet.cpp
+++ b/DirectXGame/GameObject/EnemyBullet.cpp
@@ -15,7 +15,7 @@ void EnemyBullet::EnemyBulletInitialize(const Vector3& position, const Vector3& 
 	Create();
 	// オブジェクトにモデルをひも付ける
 	SetModel(enemyBulletModel_);
-	SetScale(Vector3(0.25f, 0.25f, 0.25f));
+	SetScale(Vector3(1.5f, 1.5f, 1.5f));
 	//引数で受け取った初期座標をセット
 	worldTransform_.position_ = position;
 	//引数で受け取った速度をメンバ変数に代入

--- a/DirectXGame/GameObject/PlayerBullet.cpp
+++ b/DirectXGame/GameObject/PlayerBullet.cpp
@@ -10,12 +10,12 @@ void PlayerBullet::PlayerBulletInitialize(const Vector3& position, const Vector3
 {
 	Initialize();
 	// OBJからモデルデータを読み込む
-	playerBulletModel_ = Model::LoadFromOBJ("ironSphere_01");
+	playerBulletModel_ = Model::LoadFromOBJ("triangle_mat");
 	// 3Dオブジェクト生成
 	Create();
 	// オブジェクトにモデルをひも付ける
 	SetModel(playerBulletModel_);
-	SetScale(Vector3(0.25f, 0.25f, 0.25f));
+	SetScale(Vector3(1.5f, 1.5f, 1.5f));
 	//引数で受け取った初期座標をセット
 	worldTransform_.position_ = position;
 	//引数で受け取った速度をメンバ変数に代入

--- a/DirectXGame/GameObject/WeakEnemy.cpp
+++ b/DirectXGame/GameObject/WeakEnemy.cpp
@@ -54,37 +54,25 @@ void WeakEnemy::Move()
 {
 	switch (phase_)
 	{
-	case Phase::Curve:   //カーブフェーズ
-	default:
-		Curve();
+	case Phase::None:
 		break;
-	case Phase::ReCurve:   //カーブフェーズ
-		ReCurve();
+	case Phase::R:   //カーブフェーズ
+		RCurve();
+		break;
+	case Phase::L:   //カーブフェーズ
+		LCurve();
 		break;
 	}
 }
 
-void WeakEnemy::Curve()
+void WeakEnemy::RCurve()
 {
 	MathFunc::CurveProjection(worldTransform_, startSpeed, C, flame);
-
-	////既定の位置に着いたら逆カーブへ
-	//if (worldTransform_.position_.z <= 0.0f)
-	//{
-	//	phase_ = Phase::ReCurve;
-	//}
-
 }
 
-void WeakEnemy::ReCurve()
+void WeakEnemy::LCurve()
 {
 	MathFunc::CurveProjection(worldTransform_, { -startSpeed.x,startSpeed.y,startSpeed.z }, -C, flame);
-
-	////既定の位置に着いたら逆カーブへ
-	//if (worldTransform_.position_.z >= 100.0f)
-	//{
-	//	phase_ = Phase::Approach;
-	//}
 }
 
 Vector3 WeakEnemy::GetPosition()

--- a/DirectXGame/GameObject/WeakEnemy.h
+++ b/DirectXGame/GameObject/WeakEnemy.h
@@ -11,12 +11,13 @@ class GamePlayScene;
 
 class WeakEnemy : public Object3d
 {
+public:
 	//移動パターン
-	enum class Phase
+	enum Phase
 	{
 		None,
-		Curve,   //カーブ
-		ReCurve, //逆方向カーブ
+		R,   //右カーブ
+		L,   //左カーブ
 	};
 
 public:
@@ -31,8 +32,12 @@ public:
 	//当たり判定更新
 	void ColliderUpdate();
 
-	//gameSceneのsetter
+	//setter
+	//gameScene
 	void SetGameScene(GamePlayScene* gameScene) { gameScene_ = gameScene; }
+
+	//phase
+	void SetPhase(Phase phase) { phase_ = phase; }
 
 	bool GetIsDead() const { return isDead_; }
 
@@ -45,8 +50,8 @@ public:
 	void Move();
 
 	//カーブ
-	void Curve();
-	void ReCurve();
+	void RCurve();
+	void LCurve();
 
 	//ワールド座標を取得
 	Vector3 GetPosition();

--- a/DirectXGame/Scene/GameScene.cpp
+++ b/DirectXGame/Scene/GameScene.cpp
@@ -28,7 +28,7 @@ void GameScene::Initialize()
 	player = new Player;
 	player->PlayerInitialize();
 
-	//LoadEnemyPop();
+	/*LoadEnemyPop();*/
 	LoadWeakEnemyPop();
 
 	//パーティクル
@@ -294,6 +294,9 @@ void GameScene::UpdateWeakEnemyPop()
 		std::string key;
 		getline(line_stream, key, ' ');
 
+		std::string word;
+		getline(line_stream, word, ' ');
+
 		// 先頭文字列がwEnemyなら頂点座標
 		if (key == "wEnemy")
 		{
@@ -303,6 +306,16 @@ void GameScene::UpdateWeakEnemyPop()
 			newWEnemy->WEnemyInitialize();
 			//コライダーの追加
 			newWEnemy->SetCollider(new SphereCollider(Vector3(0, 0, 0), 1.5f));
+			//移動向き 
+			if (word.find("L") == 0)
+			{
+				newWEnemy->SetPhase(newWEnemy->L);
+			}
+			else if (word.find("R") == 0)
+			{
+				newWEnemy->SetPhase(newWEnemy->R);
+			}
+
 			// X,Y,Z座標読み込み
 			Vector3 position{};
 			line_stream >> position.x;
@@ -310,6 +323,7 @@ void GameScene::UpdateWeakEnemyPop()
 			line_stream >> position.z;
 			// 座標データに追加
 			newWEnemy->SetPosition(position);
+
 			newWEnemy->SetScale(Vector3(0.8f, 0.8f, 0.8f));
 			newWEnemy->worldTransform_.UpdateMatrix();
 			//登録
@@ -318,10 +332,10 @@ void GameScene::UpdateWeakEnemyPop()
 
 		else if (key == "wait")
 		{
-			getline(line_stream, key, ' ');
+			getline(line_stream, word, ' ');
 
 			//待ち時間
-			int32_t waitTime = atoi(key.c_str());
+			int32_t waitTime = atoi(word.c_str());
 
 			//待機開始
 			isWait_ = true;

--- a/Resources/csv/wEnemyPop.csv
+++ b/Resources/csv/wEnemyPop.csv
@@ -1,46 +1,62 @@
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L 0 0 100 
+wait 150
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
-wait 300
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy R 10 5 100 
+wait 150
+wEnemy L -10 -5 100 
 wait 20
-wEnemy 0 0 100
+wEnemy L -10 -5 100 
 wait 20
-wEnemy 0 0 100
-wait 300
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 20
+wEnemy L -10 -5 100 
+wait 150
 
 

--- a/Splite.cpp
+++ b/Splite.cpp
@@ -1,0 +1,17 @@
+#include "Splite.h"
+
+//頂点データ
+XMFLOAT3 vertices[] = {
+	{-0.5f,-0.5f,0.0f},//左下
+	{-0.5f,+0.5f,0.0f},//左上
+	{+0.5f,-0.5f,0.0f},//右下
+};
+
+//頂点データの全体のサイズ = 頂点データ一つ分のサイズ * 頂点データの要素数
+UINT sizeVB = static_cast<UINT>(sizeof(XMFLOAT3) * _countof(vertices));
+
+void Splite::Initialize(SpliteCommon* spliteCommon)
+{
+	//描画コマンド
+	spliteCommon->GetDxCommon()->GetCommandList()->DrawInstanced(_countof(vertices), 1, 0, 0);  //全ての頂点を使って描画
+}

--- a/Splite.h
+++ b/Splite.h
@@ -1,0 +1,13 @@
+#include "SpliteCommon.h"
+#include "DirectXCommon.h"
+#pragma once
+class Splite
+{
+public:
+	void Initialize(SpliteCommon* spliteCommon);
+
+private:
+	// SpliteCommonのインスタンス
+	SpliteCommon* spliteCommon = nullptr;
+};
+

--- a/Splite.hlsli
+++ b/Splite.hlsli
@@ -1,0 +1,17 @@
+//マテリアル
+//ピクセルシェーダ
+cbuffer ConstBufferDateMaterial : register(b0)
+{
+	float4 color;
+}
+cbuffer ConstBufferDataTransform : register(b1)
+{
+	matrix mat;
+}
+//頂点シェーダーの出力構造体
+//(頂点シェーダからピクセルシェーダへのやり取りに使用する)
+struct VSOutput
+{
+	float4 svpos : SV_POSITION;//システム用頂点座標
+	float2 uv : TEXCOORD;//uv値
+};

--- a/SplitePS.hlsl
+++ b/SplitePS.hlsl
@@ -1,0 +1,4 @@
+float4 main() : SV_TARGET
+{
+	return float4(1.0f, 1.0f, 1.0f, 1.0f);
+}

--- a/SpliteVS.hlsl
+++ b/SpliteVS.hlsl
@@ -1,0 +1,4 @@
+float4 main(float4 pos : POSITION) : SV_POSITION
+{
+	return pos;
+}


### PR DESCRIPTION
自機から見て右→左→右の流れになっている。
・csvの敵の数が多くなってきたので一度に出す数を指定してfor文で発生させる処理を追加したい。
・現在EnemyとWeakEnemyでcsvを分けているが、同じファイルでそれぞれ出せるようにする。敵の種類や行動パターンを増やすときも同様。