### PR TITLE
ボスの待機モーションを実装

### DIFF
--- a/DirectXGame/Application/GameObject/BackGroundObject/Meteor.cpp
+++ b/DirectXGame/Application/GameObject/BackGroundObject/Meteor.cpp
@@ -8,7 +8,7 @@ void Meteor::MeteorInitialize()
 	// 3Dオブジェクト生成
 	Create();
 
-	speed_ = 0.05f;
+	speed_ = 0.1f;
 	frontX_ = -20.0f;
 	backZ_ = 70.0f;
 	levRange_ = 1.0f;

--- a/DirectXGame/Application/GameObject/Enemy/BossEnemy.cpp
+++ b/DirectXGame/Application/GameObject/Enemy/BossEnemy.cpp
@@ -26,6 +26,7 @@ void BossEnemy::BossEnemyInitialize()
 	beforeY_ = 120.0f;
 	SetPosition({ 0.0f,beforeY_,100.0f });
 	isInit_ = false;
+	initTime_ = 240.0f;
 
 	//死亡
 	isDead_ = false;
@@ -49,14 +50,15 @@ void BossEnemy::BossEnemyInitialize()
 	waitTimer_ = 0.0f;
 	waitTimerMax_ = 300.0f;
 	waitMotionTimer_ = 0.0f;
-	waitMotionTimerMax_ = 30.0f;
-	initTime_ = 240.0f;
+	waitMotionTimerMax_ = 150.0f;
+	waitMotionRange_ = 1.0f;
+	isUp_ = false;
 
 	//離脱
 	leaveTimer_ = 0.0f;
 	leaveTimerMax_ = 120.0f;
 
-	phase_ = Phase::Turn;
+	phase_ = Phase::Wait;
 
 	hp_ = 50;
 }
@@ -137,7 +139,36 @@ void BossEnemy::Wait()
 
 void BossEnemy::WaitMotion()
 {
-
+	//上昇
+	if (isUp_ == true)
+	{
+		if (waitMotionTimer_ < waitMotionTimerMax_)
+		{
+			worldTransform_.position_.y = beforeY_ + waitMotionRange_ * MathFunc::easeOutSine(waitMotionTimer_ / waitMotionTimerMax_);
+			waitMotionTimer_++;
+		}
+		else
+		{
+			isUp_ = false;
+			waitMotionTimer_ = 0;
+			beforeY_ = worldTransform_.position_.y;
+		}
+	}
+	//下降
+	else
+	{
+		if (waitMotionTimer_ < waitMotionTimerMax_)
+		{
+			worldTransform_.position_.y = beforeY_ + waitMotionRange_ * -MathFunc::easeOutSine(waitMotionTimer_ / waitMotionTimerMax_);
+			waitMotionTimer_++;
+		}
+		else
+		{
+			isUp_ = true;
+			waitMotionTimer_ = 0;
+			beforeY_ = worldTransform_.position_.y;
+		}
+	}
 }
 
 void BossEnemy::Move()
@@ -237,9 +268,9 @@ void BossEnemy::TurnAttack(Vector3 pos)
 		if (turnAttackTimer_ < turnAttackTimerMax_)
 		{
 			//自機の位置に接近
-			worldTransform_.position_.x = turnAttackPos_.x + (turnAttackPos_.x + playerPos_.x) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
-			worldTransform_.position_.y = turnAttackPos_.y + (turnAttackPos_.y + playerPos_.y) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
-			worldTransform_.position_.z = turnAttackPos_.z + (turnAttackPos_.z + playerPos_.z) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
+			worldTransform_.position_.x = turnAttackPos_.x + (turnAttackPos_.x - playerPos_.x) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
+			worldTransform_.position_.y = turnAttackPos_.y + (turnAttackPos_.y - playerPos_.y) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
+			worldTransform_.position_.z = turnAttackPos_.z + (turnAttackPos_.z - playerPos_.z + 3.0f) * -MathFunc::easeOutSine(turnAttackTimer_ / turnAttackTimerMax_);
 			turnAttackTimer_++;
 		}
 		else
@@ -266,6 +297,7 @@ void BossEnemy::InitMotion()
 			//初期位置をセット
 			normalPos_ = worldTransform_.position_;
 			turnAttackPos_ = GetPosition();
+			beforeY_ = worldTransform_.position_.y;
 		}
 	}
 }
@@ -300,13 +332,13 @@ void BossEnemy::Leave()
 		//原点に戻る
 		worldTransform_.position_.x = beforeLeavePos_.x + (turnAttackPos_.x - beforeLeavePos_.x) * MathFunc::easeOutSine(leaveTimer_ / leaveTimerMax_);
 		worldTransform_.position_.y = beforeLeavePos_.y + (turnAttackPos_.y - beforeLeavePos_.y) * MathFunc::easeOutSine(leaveTimer_ / leaveTimerMax_);
-		worldTransform_.position_.z = beforeLeavePos_.z + (turnAttackPos_.z - beforeLeavePos_.z) * MathFunc::easeOutSine(leaveTimer_ / leaveTimerMax_);
+		worldTransform_.position_.z = beforeLeavePos_.z + (turnAttackPos_.z - beforeLeavePos_.z - 3.0f) * MathFunc::easeOutSine(leaveTimer_ / leaveTimerMax_);
 		leaveTimer_++;
 	}
 	else
 	{
 		leaveTimer_ = 0.0f;
-		isTurn_ = true;
+		isTurn_ = false;
 		phase_ = Phase::Wait;
 	}
 }

--- a/DirectXGame/Application/GameObject/Enemy/BossEnemy.h
+++ b/DirectXGame/Application/GameObject/Enemy/BossEnemy.h
@@ -133,12 +133,8 @@ private:
 	float waitMotionTimerMax_;
 	//前のy座標
 	float beforeY_;
-	//浮上モーションの時間
-	float levTime_;
-	//浮上する向き
-	int levDirection_;
 	//範囲
-	float levRange_;
+	float waitMotionRange_;
 	//上昇しているか
 	bool isUp_;
 

--- a/DirectXGame/Application/Scene/GamePlayScene.h
+++ b/DirectXGame/Application/Scene/GamePlayScene.h
@@ -305,6 +305,8 @@ private://メンバ変数
 	bool isWait_;
 	//クリア演出フラグ
 	bool isClearScene_;
+	//敵を倒した時のカメラシェイク
+	bool isEnemyDeadCameraShake_;
 	//敵死亡時のパーティクルフラグ
 	bool isBossEffect_;
 	//ボス死亡フラグ
@@ -333,8 +335,10 @@ private://メンバ変数
 	int waitTimer_;
 	//Clearに移行する演出のタイマー
 	float clearTimer_;
-	//敵の攻撃に当たった時の演出時間
-	int hitTimer_;
+	//敵が死んだ時の演出時間
+	int hitEnemyTimer_;
+	//自機が攻撃に当たった時の演出時間
+	int hitPlayerTimer_;
 	//ボス登場タイマー
 	int bossInitTimer_;
 	//スタート演出


### PR DESCRIPTION
待機→回転攻撃→待機のループが問題なくできている。

他に道中の敵を倒した時にカメラシェイクを入れ、ボス死亡時のカメラシェイクの処理をランダムシェイクと元座標を交互に移動するものにした。