### PR TITLE
エディタ機能の改善

### DIFF
--- a/DirectXGame/Application/Camera/CameraEditor.h
+++ b/DirectXGame/Application/Camera/CameraEditor.h
@@ -42,6 +42,9 @@ public:
 	//始点と終点追加
 	void Add();
 
+	//リセット
+	void ResetCamera();
+
 	//削除
 	void Delete();
 
@@ -80,6 +83,7 @@ private:
 
 	//始点と終点(セット)
 	std::list<std::unique_ptr<CameraObject>> cameraObjects_;
+	std::unique_ptr<CameraObject > cameraObject_;
 
 	//UI
 	std::unique_ptr <UI> ui_;
@@ -102,13 +106,16 @@ private:
 	//カメラと対象の距離
 	float eyeZ_;
 
-	//y変動値
-	float yNum_;
+	//カメラ限度
+	Vector3 eyeLim_;
 
 	//アングル
 	float angle_;
 	float angleNum_;
 	//角度
 	float r_;
+
+	//オブジェクトの移動限度
+	float posLimit_;
 };
 

--- a/DirectXGame/Application/Camera/CameraObject.cpp
+++ b/DirectXGame/Application/Camera/CameraObject.cpp
@@ -8,12 +8,41 @@
 
 void CameraObject::CObjectInitialize()
 {
-	Initialize();
-
 	// OBJからモデルデータを読み込む
-	cameraObjectModel_ = Model::LoadFromOBJ("cameraObject");
-	// 3Dオブジェクト生成
-	Create();
-	// オブジェクトにモデルをひも付ける
-	SetModel(cameraObjectModel_.get());
+	for (int i = 0; i < 2; i++)
+	{
+	cameraObjectModel_[i] = Model::LoadFromOBJ("cameraObject");
+		//生成
+		cameraObject_[i] = std::make_unique <Object3d>();
+		//初期化
+		cameraObject_[i]->Initialize();
+		// 3Dオブジェクト生成
+		cameraObject_[i]->Create();
+		// オブジェクトにモデルをひも付ける
+		cameraObject_[i]->SetModel(cameraObjectModel_[i].get());
+	}
+	cameraObject_[0]->SetPosition({ 0.0f, 0.0f, 0.0f });
+	cameraObject_[1]->SetPosition({ 10.0f, 0.0f, 0.0f });
+}
+
+void CameraObject::CObjectUpdate()
+{
+	for (int i = 0; i < 2; i++)
+	{
+		//更新
+		cameraObject_[i]->Update();
+	}
+}
+
+void CameraObject::CObjectDraw(ViewProjection* viewProjection)
+{
+	//始点と終点を描画
+	cameraObject_[0]->Draw(viewProjection, 1.0f, Vector3(1.0f, 1.0f, 1.0f));
+	cameraObject_[1]->Draw(viewProjection, 1.0f, Vector3(1.0f, 0.0f, 0.0f));
+}
+
+void CameraObject::Reset()
+{
+	cameraObject_[0]->SetPosition({ 0.0f, 0.0f, 0.0f });
+	cameraObject_[1]->SetPosition({ 10.0f, 0.0f, 0.0f });
 }

--- a/DirectXGame/Application/Camera/CameraObject.h
+++ b/DirectXGame/Application/Camera/CameraObject.h
@@ -8,11 +8,23 @@
 #include "Object3d.h"
 
 #pragma once
-class CameraObject : public Object3d
+class CameraObject
 {
 public:
 	//初期化
 	void CObjectInitialize();
+
+	//更新
+	void CObjectUpdate();
+
+	//描画
+	void CObjectDraw(ViewProjection*viewProjection);
+
+	//リセット
+	void Reset();
+
+	Object3d* GetCameraStart() { return cameraObject_[0].get(); }
+	Object3d* GetCameraEnd() { return cameraObject_[1].get(); }
 
 	//削除フラグ
 	bool GetIsDelete() const { return isDelete_; }
@@ -29,7 +41,10 @@ public:
 
 private:
 	// モデル
-	std::unique_ptr <Model> cameraObjectModel_;
+	std::unique_ptr <Model> cameraObjectModel_[2];
+
+	//オブジェクト
+	std::unique_ptr <Object3d> cameraObject_[2];
 
 	//削除フラグ
 	bool isDelete_;

--- a/DirectXGame/Engine/Scene/Game.cpp
+++ b/DirectXGame/Engine/Scene/Game.cpp
@@ -14,8 +14,8 @@ void Game::Initialize()
 	SIFrameWork::Initialize();
 
 	// シーンファクトリを生成し、マネージャにセット
-	sceneFactory_ = new SceneFactory();
-	sceneManager_->SetSceneFactory(sceneFactory_);
+	sceneFactory_ = std::make_unique<SceneFactory>();
+	sceneManager_->SetSceneFactory(sceneFactory_.get());
 	// シーンマネージャに最初のシーンをセット
 	sceneManager_->ChangeScene("CAMERAEDITOR");
 }

--- a/DirectXGame/Engine/Scene/SIFrameWork.cpp
+++ b/DirectXGame/Engine/Scene/SIFrameWork.cpp
@@ -37,8 +37,6 @@ void SIFrameWork::Initialize()
 void SIFrameWork::Finalize()
 {
 	sceneManager_->Destroy();
-	//シーンファクトリの解放
-	delete sceneFactory_;
 
 	// imguiの終了処理
 	imGuiManager_->Finalize();

--- a/DirectXGame/Engine/Scene/SIFrameWork.h
+++ b/DirectXGame/Engine/Scene/SIFrameWork.h
@@ -50,7 +50,7 @@ protected:
 	// シーンマネージャ
 	GameSceneManager* sceneManager_ = nullptr;
 	// シーンファクトリー
-	AbstractSceneFactory* sceneFactory_ = nullptr;
+	std::unique_ptr <AbstractSceneFactory> sceneFactory_;
 	//imgui
 	SIEngine::ImGuiManager* imGuiManager_ = nullptr;
 private:

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,8 +1,20 @@
 [Window][Debug##Default]
-Pos=60,60
-Size=400,400
+Pos=29,28
+Size=367,393
 
 [Window][Dear ImGui Demo]
 Pos=25,15
 Size=550,680
+
+[Window][config 1]
+Pos=66,75
+Size=317,319
+
+[Window][CameraEditor]
+Pos=60,60
+Size=476,259
+
+[Window][CameraObject]
+Pos=77,206
+Size=110,203
 


### PR DESCRIPTION
カメラオブジェクトの座標を調整する際に始点と終点どちらにも適用されてしまっていた。
原因はImGuiのSliderFloatの名前が同じだったため。